### PR TITLE
Readthedocs Configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ python:
 
 sphinx:
   builder: html
-  configuration: docs/source/conf.py
+  configuration: docs/conf.py
   fail_on_warning: true
 
 conda:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@ build:
   tools:
     python: "mambaforge-4.10"
 
+python:
+  install:
+    - method: pip
+      path: .
+
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "mambaforge-4.10"
+
+python:
+  install:
+    - method: pip
+      path: .
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+conda:
+  environment: environment.yml

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,11 +5,6 @@ build:
   tools:
     python: "mambaforge-4.10"
 
-python:
-  install:
-    - method: pip
-      path: .
-
 sphinx:
   builder: html
   configuration: docs/conf.py

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The core algorithm is an iterative procedure:
 For more details of the basic principles of SQE->DOS conversion, please refer to Appendix of [1] and Section 6.5 "Calculation of Multiphonon Scattering" of [2].
 
 ## API doc
-See https://multiphonon.readthedocs.io/en/latest/
+See https://multiphonon.readthedocs.io/en/latest/api.html
 
 (previous http://neutrons.github.io/multiphonon/api.html)
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ The core algorithm is an iterative procedure:
 For more details of the basic principles of SQE->DOS conversion, please refer to Appendix of [1] and Section 6.5 "Calculation of Multiphonon Scattering" of [2].
 
 ## API doc
-See http://sns-chops.github.io/multiphonon/api.html
+See https://multiphonon.readthedocs.io/en/latest/
+
+(previous http://neutrons.github.io/multiphonon/api.html)
 
 ## Run tests
 Tests are run automatically at [CI](https://github.com/neutrons/multiphonon/actions)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ release = "0.1.1"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -140,7 +140,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - versioningit
   - setuptools
   - coveralls
-  - ipywidgets # used in one test
+  - ipywidgets # used in one  test
   - pip
   - pip:
     - ipywe == 0.1.3a1

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - versioningit
   - setuptools
   - coveralls
-  - ipywidgets # used in one  test
+  - ipywidgets # used in one test
   - pip
   - pip:
     - ipywe == 0.1.3a1

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - versioningit
   - setuptools
   - coveralls
-  - ipywidgets # used in one  test
+  - ipywidgets #  used in one  test
   - pip
   - pip:
     - ipywe == 0.1.3a1

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - versioningit
   - setuptools
   - coveralls
-  - ipywidgets #  used in one  test
+  - ipywidgets # used in one  test
   - pip
   - pip:
     - ipywe == 0.1.3a1

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - check-wheel-contents
   - conda-build
   - conda-verify
-  - conda-build
   - coverage
   - histogram == 0.3.9
   - numpy == 1.20.3
@@ -24,6 +23,9 @@ dependencies:
   - pytest
   - pytest-cov
   - python-build
+  - sphinx
+  - sphinx-rtd-theme
+  - numpydoc
   - versioningit
   - setuptools
   - coveralls


### PR DESCRIPTION
# Short description of the changes:
Configuration added for readthedocs website. Existing documentation (source files) with sphinx are used.
(related to [EWM5114](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=5114)) 

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->
The code includes the following:
-  environment.yml with sphinx-related package
- readthedocs yaml file
- update to existing documentation configuration
- readthedocs hook is activated on the PR for every future PR (from readthedocs)

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
