### PR TITLE
using mantid-ornl

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - scipy
     - matplotlib
     - mantid
-    - muparser < 2.3.5
+    - muparser <2.3.5
 
   test:
     imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,6 +41,7 @@ requirements:
     - scipy
     - matplotlib
     - mantid
+    - muparser < 2.3.5
 
   test:
     imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -41,7 +41,6 @@ requirements:
     - scipy
     - matplotlib
     - mantid
-    - muparser <2.3.5
 
   test:
     imports:

--- a/environment.yml
+++ b/environment.yml
@@ -34,3 +34,4 @@ dependencies:
   - ipywidgets # used in one test
   - histogram
   - git-lfs
+  - muparser < 2.3.5

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - scipy == 1.14.1
   - python >=3.10
   - pyre == 0.8.3
-  - mantid >= 6.12.0
+  - mantid == 6.12.0.2
   - matplotlib
   - libmamba
   - libarchive

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 #Note: Use this
 name: multiphonon
 channels:
-  - mantid
+  - mantid-ornl
   - neutrons/label/rc
   - mcvine
   - conda-forge
@@ -34,4 +34,3 @@ dependencies:
   - ipywidgets # used in one test
   - histogram
   - git-lfs
-  - muparser < 2.3.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.10"
 dependencies = [
   "numpy >= 1.26.4",
   "scipy == 1.14.1",
-  "mantid >= 6.12.0",
+  "mantid == 6.12.0.2",
 ]
 license = { text = "BSD" }
 keywords= ["neutron, inelastic neutron scattering, powder, phonon"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
   "numpy >= 1.26.4",
   "scipy == 1.14.1",
   "mantid >= 6.12.0",
-  "muparser < 2.3.5",
 ]
 license = { text = "BSD" }
 keywords= ["neutron, inelastic neutron scattering, powder, phonon"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "numpy >= 1.26.4",
   "scipy == 1.14.1",
   "mantid >= 6.12.0",
+  "muparser < 2.3.5",
 ]
 license = { text = "BSD" }
 keywords= ["neutron, inelastic neutron scattering, powder, phonon"]


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
muparser is breaking mantid which affects multiphonon. Switching to mantid-ornl will use latest ornl's mantid v6.12.0.2 which fixes this issue.
# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
